### PR TITLE
Add note about webhook response status codes and retries

### DIFF
--- a/guides/notifications.md
+++ b/guides/notifications.md
@@ -239,7 +239,7 @@ Note: All e-mail addresses will have to be verified on a **per-repository** basi
 
 An HTTP POST call will be made to the specified URL with the event's data (see above for each event's data format).
 
-When the URL is HTTPS, the call will have an SSL client certificate set from Quay.io. Verification of this certificate will prove the call originated from Quay.io.
+When the URL is HTTPS, the call will have an SSL client certificate set from Quay.io. Verification of this certificate will prove the call originated from Quay.io. Responses with status codes in the 2xx range are considered successful. Responses with any other status codes will be considered failures and result in a retry of the webhook notification.
 
 #### <i class="fa fa-lg method-icon hipchat-icon"></i>Hipchat Notification
 <a name="hipchat"></a>


### PR DESCRIPTION
Per discussion in the #quay IRC channel, response status codes have an
effect on webhook notification behavior. This is useful information for
developers building applications that respond to webhooks, so it should
be added to the documentation.
